### PR TITLE
Add Settings initialization utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ note.
 - Individual example snippets
 
 ```javascript
-import openInApp from '@matt-block/react-native-in-app-browser';
+import openInApp from "@matt-block/react-native-in-app-browser";
 
 
 // Minimal setup.
@@ -96,6 +96,47 @@ platform:
 openInApp("https://www.wikipedia.org/", {
   android: {},
   ios: {}
+});
+```
+
+Settings can also be initialized separately with `initialize` so that each `openInApp` call won't need to specify them each time:
+
+```javascript
+import openInApp, { initialize } from "@matt-block/react-native-in-app-browser";
+
+// Somewhere in your app initialization logic.
+initialize({
+  android: {},
+  ios: {}
+});
+
+// Other part of your code base.
+// Previously initialized settings will apply.
+openInApp("https://www.wikipedia.org/");
+```
+
+Note that `openInApp` will still accept settings as always but will effectively perform a merge between the initialized properties and the provided settings object (which will have priority over the initialized properties):
+
+```javascript
+import openInApp, { initialize } from "@matt-block/react-native-in-app-browser";
+
+// Somewhere in your app initialization logic.
+initialize({
+  android: {
+    toolbarColor: "red",
+    showTitle: true
+  }
+});
+
+// Other part of your code base.
+// Merged settings for this call will result in:
+//
+// - toolbarColor: "blue",
+// - showTitle: true
+openInApp("https://www.wikipedia.org/", {
+  android: {
+    toolbarColor: "blue"
+  }
 });
 ```
 

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -31,3 +31,5 @@ declare export default function openInApp(
   url: string,
   settings?: Settings
 ): Promise<{}>;
+
+declare export function initialize(settings: Settings): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@
 
 import { NativeModules, Platform } from "react-native";
 import { isUrlValid } from "./utils/validation";
-import { sanitize, Settings } from "./settings";
+import { sanitize, initialize, Settings } from "./settings";
 
 /**
  * Open a URL in app.
@@ -25,4 +25,4 @@ async function openInApp(url: string, settings?: Settings) {
   NativeModules.RNInAppBrowser.openInApp(url, sanitize(Platform.OS, settings));
 }
 
-export default openInApp;
+export { openInApp as default, initialize };

--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -5,9 +5,22 @@
  * file in the root directory of this source tree.
  */
 
-import { sanitize } from "./settings";
+import {
+  sanitize,
+  initialize,
+  SettingsAndroid,
+  Settings,
+  defaultSettings
+} from "./settings";
 
 describe("Sanitize settings - Android", () => {
+  beforeEach(() => {
+    initialize({
+      android: {},
+      ios: {}
+    });
+  });
+
   it("filters out invalid toolbarColor", () => {
     expect(
       sanitize("android", {
@@ -56,9 +69,36 @@ describe("Sanitize settings - Android", () => {
       toolbarColor: "#33ffFF"
     });
   });
+
+  it("returns default settings for non provided ones", () => {
+    const settings: Settings = {
+      android: {
+        toolbarColor: "red"
+      }
+    };
+    initialize(settings);
+
+    expect(
+      sanitize("android", {
+        android: {
+          showTitle: true
+        }
+      })
+    ).toEqual({
+      toolbarColor: "red",
+      showTitle: true
+    });
+  });
 });
 
 describe("Sanitize settings - iOS", () => {
+  beforeEach(() => {
+    initialize({
+      android: {},
+      ios: {}
+    });
+  });
+
   it("filters out invalid preferredBarTintColor", () => {
     expect(
       sanitize("ios", {
@@ -99,6 +139,58 @@ describe("Sanitize settings - iOS", () => {
     ).toEqual({
       preferredBarTintColor: "#33ffFF",
       barCollapsingEnabled: true
+    });
+  });
+
+  it("returns default settings for non provided ones", () => {
+    const settings: Settings = {
+      ios: {
+        preferredBarTintColor: "#3fF"
+      }
+    };
+    initialize(settings);
+
+    expect(
+      sanitize("ios", {
+        ios: {
+          preferredControlTintColor: "#3fF",
+          barCollapsingEnabled: true
+        }
+      })
+    ).toEqual({
+      preferredBarTintColor: "#33ffFF",
+      preferredControlTintColor: "#33ffFF",
+      barCollapsingEnabled: true
+    });
+  });
+});
+
+describe("Initialize", () => {
+  beforeEach(() => {
+    initialize({
+      android: {},
+      ios: {}
+    });
+  });
+
+  it("correctly initializes default settings", () => {
+    const settings: Settings = {
+      android: {
+        toolbarColor: "red"
+      },
+      ios: {
+        preferredBarTintColor: "#3fF"
+      }
+    };
+    initialize(settings);
+
+    expect(defaultSettings).toEqual({
+      android: {
+        toolbarColor: "red"
+      },
+      ios: {
+        preferredBarTintColor: "#33ffFF"
+      }
     });
   });
 });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -135,18 +135,46 @@ export interface SettingsIOS {
 }
 
 /**
+ * Default settings.
+ *
+ * These values can be augmented throgh initialization.
+ */
+export const defaultSettings: Settings = {
+  android: {},
+  ios: {}
+};
+
+/**
+ * Initializes the platform-specific settings for the in-app browser
+ * experience.
+ *
+ * This utility function is useful when `openInApp` is used in several
+ * portions of the application code base as it allows to provide the
+ * settings only once instead of specifing them with each call.
+ */
+export function initialize(settings: Settings) {
+  // First, reset directly as `sanitize` will otherwise merge with
+  // previous defaults: it would not be possible to remove properties.
+  defaultSettings.android = {};
+  defaultSettings.ios = {};
+
+  defaultSettings.android = sanitize("android", settings) as SettingsAndroid;
+  defaultSettings.ios = sanitize("ios", settings) as SettingsIOS;
+}
+
+/**
  * Sanitize the settings based on the running OS.
+ *
+ * Provided settings will be merged with the default ones.
+ * Also, in case of same properties, provided ones have priority
+ * over defaults.
  */
 export function sanitize(os: PlatformOSType, settings?: Settings) {
-  if (!settings) {
-    return {};
-  }
-
   switch (os) {
     case "android":
-      return sanitizeAndroid(settings.android);
+      return sanitizeAndroid(settings ? settings.android : {});
     case "ios":
-      return sanitizeIOS(settings.ios);
+      return sanitizeIOS(settings ? settings.ios : {});
     // Other platforms in the future.
     default:
       return {};
@@ -154,7 +182,7 @@ export function sanitize(os: PlatformOSType, settings?: Settings) {
 }
 
 function sanitizeAndroid(settings?: SettingsAndroid): SettingsAndroid {
-  const sanitizedSettings: SettingsAndroid = {};
+  const sanitizedSettings = defaultSettings.android!;
 
   if (!settings) {
     return sanitizedSettings;
@@ -194,7 +222,7 @@ function sanitizeAndroid(settings?: SettingsAndroid): SettingsAndroid {
 }
 
 function sanitizeIOS(settings?: SettingsIOS): SettingsIOS {
-  const sanitizedSettings: SettingsIOS = {};
+  const sanitizedSettings = defaultSettings.ios!;
 
   if (!settings) {
     return sanitizedSettings;


### PR DESCRIPTION
The settings now have a `defaultSettings` object with can be initialized with the new `initialize` function.

This utility can be quite useful for scenarios where `openInApp` is used in several places and the settings are always the same: inizializing would mean that `openInApp` would need only the mandatory url and nothing more.