### PR TITLE
Add close in app browser instance feature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,4 +25,16 @@ async function openInApp(url: string, settings?: Settings) {
   NativeModules.RNInAppBrowser.openInApp(url, sanitize(Platform.OS, settings));
 }
 
-export { openInApp as default, initialize };
+/**
+ * Close the current in app browser instance.
+ *
+ * This feature is iOS only as Chrome Custom Tabs does not support programmatic
+ * dismissal.
+ */
+function closeInAppInstance() {
+  if (Platform.OS === "ios") {
+    NativeModules.RNInAppBrowser.closeInApp();
+  }
+}
+
+export { openInApp as default, closeInAppInstance, initialize };

--- a/src/ios/RNInAppBrowser/RNInAppBrowser.swift
+++ b/src/ios/RNInAppBrowser/RNInAppBrowser.swift
@@ -12,6 +12,7 @@ class RNInAppBrowser: NSObject {
     private let SETTING_BARTINT = "preferredBarTintColor"
     private let SETTING_CONTROLTINT = "preferredControlTintColor"
     private let SETTING_COLLAPSEBAR = "barCollapsingEnabled"
+    private let presentedSafariVC = RCTPresentedViewController()
     
     @objc(openInApp:settings:)
     func openInApp(url: String, settings: NSDictionary) -> Void {
@@ -23,7 +24,6 @@ class RNInAppBrowser: NSObject {
             let safariVC = SFSafariViewController(url: url)
             customize(safariView: safariVC, settings: settings)
             
-            let presentedVC = RCTPresentedViewController();
             presentedVC?.present(safariVC, animated: true)
         }
         
@@ -51,6 +51,11 @@ class RNInAppBrowser: NSObject {
             let collapse = settings.value(forKey: SETTING_COLLAPSEBAR) as! Bool
             safariView.configuration.barCollapsingEnabled = collapse
         }
+    }
+
+    @objc(closeInApp)
+    func closeInApp() -> Void {
+        presentedSafariVC?.dismiss(animated: true)
     }
     
     /// See [Difference requiresMainQueueSetup and dispatch_get_main_queue?](https://stackoverflow.com/a/50775641)

--- a/src/ios/RNInAppBrowser/RNInAppBrowserBridge.m
+++ b/src/ios/RNInAppBrowser/RNInAppBrowserBridge.m
@@ -11,5 +11,6 @@
 @interface RCT_EXTERN_MODULE(RNInAppBrowser, NSObject)
 
 RCT_EXTERN_METHOD(openInApp:(NSString *)url settings:(NSDictionary *)settings)
+RCT_EXTERN_METHOD(closeInApp)
 
 @end


### PR DESCRIPTION
This feature is iOS only as Chrome Custom Tabs does not support programmatic dismissal.